### PR TITLE
docs: add public problem repository indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2026-09-07 — 公共 README、AI 发现与 GEO 维护面
 
+- 在 README 首屏和公共问题索引中增加 GitHub Project #1、公共 ProblemContract 问题库、单问题模板、公开仓库列表以及六个未闭合千禧年问题与 secp256k1 关键问题仓库的直达索引；所有链接保持 pointer-only，不把仓库活动解释为数学证据或已解决声明。
 - 确立 Point–Line–Face–Body（PLFB）为唯一概念元模型根：PWTSJ 归入 F05 过程面，OSPS 归入 F04 结果空间面；公开 Face/Body、跨面绑定和状态非传播边界。
 - 同步 README/GEO/AI citation/Schema.org/codemeta/架构图与公共声明；明确本次仅发布概念标准，不宣称 PLFB registry、Body runtime、OSPS orchestrator、通用 PWTSJ scheduler 或统一 Observation Ledger 已实现。
 - 重构中英文 README 首屏，统一项目实体、公共 URL、当前空 ledger 状态、快速开始和证据边界。

--- a/README.en.md
+++ b/README.en.md
@@ -14,6 +14,30 @@
 
 Canonical public repository: <https://github.com/vibemathing/vibe-mathing-cn-public>
 
+### Public entrypoint index
+
+| Entrypoint | Purpose |
+| --- | --- |
+| [Problem repository fleet · GitHub Project #1](https://github.com/users/vibemathing/projects/1) | Browse public single-problem repositories; Project fields and cards are operational indexes, not mathematical evidence |
+| [Public ProblemContract library](https://github.com/vibemathing/vibe-mathing-problem-library-public) | Discover public problem contracts, the catalog, and repository locators |
+| [Single-problem research template](https://github.com/vibemathing/vibe-mathing-problem-public-template) | Inspect the fixed Web research Harness, candidate-write boundary, and bootstrap files |
+| [All public `vibemathing` repositories](https://github.com/vibemathing?tab=repositories) | Find concrete `problem-*` repositories and other public engineering repositories |
+| [Detailed public problem index in this repository](problem-library/VIBEMATHING_PUBLIC_INDEX.md) | Read the catalog, template, query commands, and admission boundary |
+
+### Key problem repositories
+
+> These are ProblemContract/candidate-research entrypoints only. A repository, Issue, PR, CI run, or checkpoint does not mean that a problem has been solved and does not automatically create Evidence, a Result, or a Solution. The secp256k1 entry is not a Millennium Prize Problem.
+
+| Problem | Public single-problem repository |
+| --- | --- |
+| Riemann hypothesis | [`problem-millennium-riemann-hypothesis`](https://github.com/vibemathing/problem-millennium-riemann-hypothesis) |
+| P versus NP | [`problem-millennium-p-vs-np`](https://github.com/vibemathing/problem-millennium-p-vs-np) |
+| Navier–Stokes existence and smoothness | [`problem-millennium-navier-stokes`](https://github.com/vibemathing/problem-millennium-navier-stokes) |
+| Yang–Mills existence and mass gap | [`problem-millennium-yang-mills-mass-gap`](https://github.com/vibemathing/problem-millennium-yang-mills-mass-gap) |
+| Hodge conjecture | [`problem-millennium-hodge-conjecture`](https://github.com/vibemathing/problem-millennium-hodge-conjecture) |
+| Birch and Swinnerton-Dyer conjecture | [`problem-millennium-birch-swinnerton-dyer`](https://github.com/vibemathing/problem-millennium-birch-swinnerton-dyer) |
+| Classical polynomial-time audit of secp256k1 discrete-log inversion | [`problem-secp256k1-ecdlog-polytime`](https://github.com/vibemathing/problem-secp256k1-ecdlog-polytime) |
+
 `vibe-mathing-cn` organizes mathematical problems, literature, derivations, computations, proofs, and formal checks into a traceable workflow. It is not a promise to solve arbitrary open problems: an honest `open` disposition is a valid outcome.
 
 The repository's original code and documentation are released under the [MIT License](LICENSE); third-party material under `vendor/` remains subject to its own license and source lock.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,30 @@
 
 公共仓库地址：<https://github.com/vibemathing/vibe-mathing-cn-public>
 
+### 公开入口索引
+
+| 入口 | 用途 |
+| --- | --- |
+| [问题仓库总览 · GitHub Project #1](https://github.com/users/vibemathing/projects/1) | 浏览公开单问题仓库；Project、字段和卡片是运营索引，不是数学证据 |
+| [公共 ProblemContract 问题库](https://github.com/vibemathing/vibe-mathing-problem-library-public) | 查找公开问题合同、catalog 和仓库 locator |
+| [单问题研究模板仓库](https://github.com/vibemathing/vibe-mathing-problem-public-template) | 查看固定 Web research Harness、候选写入边界与启动文件 |
+| [全部 `vibemathing` 公开仓库](https://github.com/vibemathing?tab=repositories) | 查找具体 `problem-*` 仓库及其他公共工程仓库 |
+| [本仓库的详细公共问题索引](problem-library/VIBEMATHING_PUBLIC_INDEX.md) | 阅读 catalog、模板、查询命令和准入边界 |
+
+### 关键问题仓库
+
+> 以下均为 ProblemContract/候选研究入口。仓库、Issue、PR、CI 或 checkpoint 的存在不表示问题已解决，也不自动产生 Evidence、Result 或 Solution；secp256k1 条目不属于千禧年问题。
+
+| 问题 | 公开单问题仓库 |
+| --- | --- |
+| 黎曼猜想 | [`problem-millennium-riemann-hypothesis`](https://github.com/vibemathing/problem-millennium-riemann-hypothesis) |
+| P 与 NP 问题 | [`problem-millennium-p-vs-np`](https://github.com/vibemathing/problem-millennium-p-vs-np) |
+| Navier–Stokes 方程存在性与光滑性 | [`problem-millennium-navier-stokes`](https://github.com/vibemathing/problem-millennium-navier-stokes) |
+| Yang–Mills 理论存在性与质量间隙 | [`problem-millennium-yang-mills-mass-gap`](https://github.com/vibemathing/problem-millennium-yang-mills-mass-gap) |
+| 霍奇猜想 | [`problem-millennium-hodge-conjecture`](https://github.com/vibemathing/problem-millennium-hodge-conjecture) |
+| Birch–Swinnerton-Dyer 猜想 | [`problem-millennium-birch-swinnerton-dyer`](https://github.com/vibemathing/problem-millennium-birch-swinnerton-dyer) |
+| secp256k1 离散对数经典多项式时间性审计 | [`problem-secp256k1-ecdlog-polytime`](https://github.com/vibemathing/problem-secp256k1-ecdlog-polytime) |
+
 ## 30 秒理解
 
 | 你想知道 | 直接答案 |

--- a/problem-library/VIBEMATHING_PUBLIC_INDEX.md
+++ b/problem-library/VIBEMATHING_PUBLIC_INDEX.md
@@ -2,13 +2,28 @@
 
 本页把本仓库与 `https://github.com/vibemathing` 的公开问题生态接起来，但**不复制远端研究仓库**。远端内容、仓库状态和题面可能变化；下列数量与列表是基于公开 `LIBRARY_SNAPSHOT.json` / `catalog/canonical-index.json` 在 **2026-09-07** 的观察，开始研究前必须重新读取远端入口。
 
-## 三类公开入口
+## 公开入口
 
 | 入口 | 作用 | 是否是本仓库的本地真相源 |
 | --- | --- | --- |
+| [问题仓库总览 · GitHub Project #1](https://github.com/users/vibemathing/projects/1) | 跨仓库运营索引，集中导航公开单问题仓库 | 否；Project、字段、view 和卡片不是数学 Evidence 或 Result |
 | [`vibe-mathing-problem-library-public`](https://github.com/vibemathing/vibe-mathing-problem-library-public) | 问题总库：公开的 ProblemContract 发现与准入目录 | 否；它是外部来源，不能自动写入本仓库 canonical ledger |
 | [`vibe-mathing-problem-public-template`](https://github.com/vibemathing/vibe-mathing-problem-public-template) | 单问题网页版研究模板，含固定 Web research Harness | 否；模板和 transport 不能自动产生 Result |
 | [`vibemathing` 公开仓库列表](https://github.com/vibemathing?tab=repositories) | 具体 `problem-*` 研究仓库的导航入口 | 否；仓库名只是 locator，不是数学结论 |
+
+## 关键问题快捷入口
+
+下列链接是公开单问题仓库 locator，不是本仓库 canonical ledger 的副本。六个千禧年条目仍按未闭合开放问题处理；secp256k1 条目是独立的密码学复杂性审计问题，不属于千禧年问题。任何仓库、Issue、PR、CI、checkpoint 或候选文件都不能据此晋升为 Evidence、Result 或 Solution。
+
+| 类别 | 问题 | 公开单问题仓库 |
+| --- | --- | --- |
+| 千禧年问题 | 黎曼猜想 | [`problem-millennium-riemann-hypothesis`](https://github.com/vibemathing/problem-millennium-riemann-hypothesis) |
+| 千禧年问题 | P 与 NP 问题 | [`problem-millennium-p-vs-np`](https://github.com/vibemathing/problem-millennium-p-vs-np) |
+| 千禧年问题 | Navier–Stokes 方程存在性与光滑性 | [`problem-millennium-navier-stokes`](https://github.com/vibemathing/problem-millennium-navier-stokes) |
+| 千禧年问题 | Yang–Mills 理论存在性与质量间隙 | [`problem-millennium-yang-mills-mass-gap`](https://github.com/vibemathing/problem-millennium-yang-mills-mass-gap) |
+| 千禧年问题 | 霍奇猜想 | [`problem-millennium-hodge-conjecture`](https://github.com/vibemathing/problem-millennium-hodge-conjecture) |
+| 千禧年问题 | Birch–Swinnerton-Dyer 猜想 | [`problem-millennium-birch-swinnerton-dyer`](https://github.com/vibemathing/problem-millennium-birch-swinnerton-dyer) |
+| 独立关键问题 | secp256k1 离散对数经典多项式时间性审计 | [`problem-secp256k1-ecdlog-polytime`](https://github.com/vibemathing/problem-secp256k1-ecdlog-polytime) |
 
 公共问题总库的机器入口：
 

--- a/problem-library/registry/vibemathing-public-source.v1.json
+++ b/problem-library/registry/vibemathing-public-source.v1.json
@@ -7,6 +7,16 @@
     "api_url": "https://api.github.com/users/vibemathing/repos?per_page=100&sort=updated",
     "kind": "public GitHub namespace"
   },
+  "project_index": {
+    "owner": "vibemathing",
+    "number": 1,
+    "title": "Vibe Mathing · Problem Repository Fleet",
+    "url": "https://github.com/users/vibemathing/projects/1",
+    "visibility": "public",
+    "source_role": "cross-repository operational navigation",
+    "mathematical_status": "Project fields, views, and cards are not Evidence, Result, or Solution",
+    "observed_on": "2026-09-07"
+  },
   "repositories": [
     {
       "role": "problem-library",
@@ -29,6 +39,59 @@
       "observed_on": "2026-09-07"
     }
   ],
+  "key_problem_repositories": [
+    {
+      "group": "open-millennium-problem",
+      "label": "Riemann hypothesis",
+      "full_name": "vibemathing/problem-millennium-riemann-hypothesis",
+      "url": "https://github.com/vibemathing/problem-millennium-riemann-hypothesis"
+    },
+    {
+      "group": "open-millennium-problem",
+      "label": "P versus NP",
+      "full_name": "vibemathing/problem-millennium-p-vs-np",
+      "url": "https://github.com/vibemathing/problem-millennium-p-vs-np"
+    },
+    {
+      "group": "open-millennium-problem",
+      "label": "Navier-Stokes existence and smoothness",
+      "full_name": "vibemathing/problem-millennium-navier-stokes",
+      "url": "https://github.com/vibemathing/problem-millennium-navier-stokes"
+    },
+    {
+      "group": "open-millennium-problem",
+      "label": "Yang-Mills existence and mass gap",
+      "full_name": "vibemathing/problem-millennium-yang-mills-mass-gap",
+      "url": "https://github.com/vibemathing/problem-millennium-yang-mills-mass-gap"
+    },
+    {
+      "group": "open-millennium-problem",
+      "label": "Hodge conjecture",
+      "full_name": "vibemathing/problem-millennium-hodge-conjecture",
+      "url": "https://github.com/vibemathing/problem-millennium-hodge-conjecture"
+    },
+    {
+      "group": "open-millennium-problem",
+      "label": "Birch and Swinnerton-Dyer conjecture",
+      "full_name": "vibemathing/problem-millennium-birch-swinnerton-dyer",
+      "url": "https://github.com/vibemathing/problem-millennium-birch-swinnerton-dyer"
+    },
+    {
+      "group": "independent-key-problem",
+      "label": "Classical polynomial-time audit of secp256k1 discrete-log inversion",
+      "full_name": "vibemathing/problem-secp256k1-ecdlog-polytime",
+      "url": "https://github.com/vibemathing/problem-secp256k1-ecdlog-polytime"
+    }
+  ],
+  "key_problem_repository_policy": {
+    "pointer_only": true,
+    "auto_import_problem_contracts": false,
+    "auto_clone_repositories": false,
+    "repository_activity_is_mathematical_evidence": false,
+    "repository_presence_is_solved_claim": false,
+    "secp256k1_is_millennium_problem": false,
+    "revalidation": "Re-read repository identity, visibility, default branch, ProblemContract, and current evidence state before use."
+  },
   "canonical_catalog_snapshot": {
     "source_repository": "vibemathing/vibe-mathing-problem-library-public",
     "index_path": "catalog/canonical-index.json",

--- a/scripts/check_public_readme.py
+++ b/scripts/check_public_readme.py
@@ -9,6 +9,16 @@ from pathlib import Path
 from typing import Any
 
 PUBLIC_URL = "https://github.com/vibemathing/vibe-mathing-cn-public"
+PUBLIC_PROJECT_URL = "https://github.com/users/vibemathing/projects/1"
+KEY_PROBLEM_REPOSITORIES = {
+    "vibemathing/problem-millennium-riemann-hypothesis": "open-millennium-problem",
+    "vibemathing/problem-millennium-p-vs-np": "open-millennium-problem",
+    "vibemathing/problem-millennium-navier-stokes": "open-millennium-problem",
+    "vibemathing/problem-millennium-yang-mills-mass-gap": "open-millennium-problem",
+    "vibemathing/problem-millennium-hodge-conjecture": "open-millennium-problem",
+    "vibemathing/problem-millennium-birch-swinnerton-dyer": "open-millennium-problem",
+    "vibemathing/problem-secp256k1-ecdlog-polytime": "independent-key-problem",
+}
 REQUIRED_FILES = (
     "README.md",
     "README.en.md",
@@ -343,6 +353,50 @@ def check_external_problem_index(root: Path) -> None:
         item = by_name.get(full_name)
         if not isinstance(item, dict) or item.get("role") != role or not isinstance(item.get("url"), str):
             raise CheckError(f"vibemathing source registry is missing {full_name}")
+    project_index = registry.get("project_index")
+    if (
+        not isinstance(project_index, dict)
+        or project_index.get("owner") != "vibemathing"
+        or project_index.get("number") != 1
+        or project_index.get("url") != PUBLIC_PROJECT_URL
+        or project_index.get("visibility") != "public"
+    ):
+        raise CheckError("vibemathing Project index identity is invalid")
+    key_repositories = registry.get("key_problem_repositories")
+    if not isinstance(key_repositories, list) or len(key_repositories) != len(KEY_PROBLEM_REPOSITORIES):
+        raise CheckError("vibemathing key problem repository index has the wrong size")
+    key_by_name: dict[str, dict[str, Any]] = {}
+    for item in key_repositories:
+        if not isinstance(item, dict) or not isinstance(item.get("full_name"), str):
+            raise CheckError("vibemathing key problem repository entry is invalid")
+        full_name = item["full_name"]
+        if full_name in key_by_name:
+            raise CheckError(f"duplicate key problem repository: {full_name}")
+        key_by_name[full_name] = item
+    if set(key_by_name) != set(KEY_PROBLEM_REPOSITORIES):
+        raise CheckError("vibemathing key problem repository identities drifted")
+    for full_name, group in KEY_PROBLEM_REPOSITORIES.items():
+        item = key_by_name[full_name]
+        expected_url = f"https://github.com/{full_name}"
+        if item.get("group") != group or item.get("url") != expected_url:
+            raise CheckError(f"vibemathing key problem repository binding is invalid: {full_name}")
+        for relative in ("README.md", "README.en.md", "problem-library/VIBEMATHING_PUBLIC_INDEX.md"):
+            if expected_url not in read_text(root, relative):
+                raise CheckError(f"key problem repository is missing from {relative}: {full_name}")
+    key_policy = registry.get("key_problem_repository_policy")
+    if (
+        not isinstance(key_policy, dict)
+        or key_policy.get("pointer_only") is not True
+        or key_policy.get("auto_import_problem_contracts") is not False
+        or key_policy.get("auto_clone_repositories") is not False
+        or key_policy.get("repository_activity_is_mathematical_evidence") is not False
+        or key_policy.get("repository_presence_is_solved_claim") is not False
+        or key_policy.get("secp256k1_is_millennium_problem") is not False
+    ):
+        raise CheckError("vibemathing key problem repository policy is unsafe")
+    for relative in ("README.md", "README.en.md", "problem-library/VIBEMATHING_PUBLIC_INDEX.md"):
+        if PUBLIC_PROJECT_URL not in read_text(root, relative):
+            raise CheckError(f"public Project index is missing from {relative}")
     snapshot = registry.get("canonical_catalog_snapshot")
     counts = snapshot.get("counts") if isinstance(snapshot, dict) else None
     if (


### PR DESCRIPTION
## Summary

- add first-screen links to GitHub Project #1, the public ProblemContract library, the single-problem template, and the public repository list
- add direct links for the six open Millennium Prize problem repositories and the secp256k1 audit repository
- bind the links in the pointer-only public source registry and validate identity/policy drift

## Boundaries

- repository and Project activity remain operational/candidate transport, not mathematical Evidence, Result, or Solution
- secp256k1 is explicitly separate from the Millennium Prize problems
- no canonical Problem, Attempt, Result, or Solution records are changed

## Validation

- `make check`
- `python3 scripts/validate_public_boundary.py --project-root . --format json`
- delta privacy audit: PASS, no new findings
- all nine linked repositories fresh-read as public, active, unarchived, default branch `main`