### PR TITLE
docs: feature secp256k1 at top of problem table

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -34,10 +34,11 @@ The dated [`Project #2 View 3 snapshot`](problem-library/BOUNTY_PROJECT_2_TOP146
 
 The six Millennium entries remain a separate category. The cryptographic `secp256k1` entry is an independent complexity-audit problem and is not part of the Millennium Problems.
 
-The table below directly lists the first 146 unique problem repositories in Project #2 View 3 order. The added bounty column preserves the original currency and includes the USD-equivalent value from this snapshot. Amounts use compact `M=millions` and `k=thousands` notation; exact values remain in the machine snapshot. Related Award records are preserved but not added; Project, repository, Issue, PR, CI, and checkpoint activity is not mathematical Evidence, Result, or Solution.
+The table first pins `secp256k1` as an independent research focus, then lists the first 146 unique problem repositories in Project #2 View 3 order. `secp256k1` is not listed in Project #2's bounty ranking, so no bounty amount is inferred for it. The added bounty column preserves the original currency and includes the USD-equivalent value from this snapshot. Amounts use compact `M=millions` and `k=thousands` notation; exact values remain in the machine snapshot. Related Award records are preserved but not added; Project, repository, Issue, PR, CI, and checkpoint activity is not mathematical Evidence, Result, or Solution.
 
 | Rank | Category | Problem / Problem Key | Bounty (original; USD reference) | Public single-problem repository |
 | ---: | --- | --- | ---: | --- |
+| Featured | Independent cryptographic focus | `secp256k1`: classical polynomial-time audit of discrete-log inversion | Bounty not listed in Project #2 | [vibemathing/problem-secp256k1-ecdlog-polytime](https://github.com/vibemathing/problem-secp256k1-ecdlog-polytime) |
 | 1 | Project #2 bounty problem | `eternity-ii`：Eternity II puzzle | USD 2M | [vibemathing/problem-eternity-ii](https://github.com/vibemathing/problem-eternity-ii) |
 | 2 | Project #2 bounty problem | `beal-million`：Beal猜想 | USD 1M | [vibemathing/problem-um-nt-078-beal-s-conjecture-c75e225d](https://github.com/vibemathing/problem-um-nt-078-beal-s-conjecture-c75e225d) |
 | 3 | Millennium problem | `clay-bsd`：Birch–Swinnerton-Dyer猜想 | USD 1M | [vibemathing/problem-millennium-birch-swinnerton-dyer](https://github.com/vibemathing/problem-millennium-birch-swinnerton-dyer) |
@@ -184,8 +185,6 @@ The table below directly lists the first 146 unique problem repositories in Proj
 | 144 | Project #2 bounty problem | `erdosproblems:104`：Erdős Problem #104 | USD 100 | [vibemathing/problem-um-ep-104-erd-s-problem-104-15bd3bf4](https://github.com/vibemathing/problem-um-ep-104-erd-s-problem-104-15bd3bf4) |
 | 145 | Project #2 bounty problem | `erdosproblems:1123`：Erdős Problem #1123 | USD 100 | [vibemathing/problem-erdosproblems-1123](https://github.com/vibemathing/problem-erdosproblems-1123) |
 | 146 | Project #2 bounty problem | `erdosproblems:119`：Erdős Problem #119 | USD 100 | [vibemathing/problem-erdosproblems-119](https://github.com/vibemathing/problem-erdosproblems-119) |
-| — | Independent cryptographic problem | `secp256k1`: classical polynomial-time audit of discrete-log inversion | Not listed in Project #2 Top 146 bounty ranking | [vibemathing/problem-secp256k1-ecdlog-polytime](https://github.com/vibemathing/problem-secp256k1-ecdlog-polytime) |
-
 `vibe-mathing-cn` organizes mathematical problems, literature, derivations, computations, proofs, and formal checks into a traceable workflow. It is not a promise to solve arbitrary open problems: an honest `open` disposition is a valid outcome.
 
 The repository's original code and documentation are released under the [MIT License](LICENSE); third-party material under `vendor/` remains subject to its own license and source lock.

--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@
 
 六个千禧年条目仍单独归类。密码学 `secp256k1` 条目是独立的复杂性审计问题，不属于千禧年问题。
 
-下面表格直接按 Project #2 View 3 的排名列出前 146 个唯一问题仓库；新增的赏金列保留原币种，并附本次快照的 USD 等值。金额使用 `M=百万`、`k=千` 的紧凑记法，精确值见机器快照。重复 Award record 不相加，Project、仓库、Issue、PR、CI 和 checkpoint 仍不是数学 Evidence、Result 或 Solution。
+下面表格先置顶 `secp256k1` 作为独立重点研究入口，再按 Project #2 View 3 的排名列出前 146 个唯一问题仓库；新增的赏金列保留原币种，并附本次快照的 USD 等值。`secp256k1` 未列入 Project #2 赏金排名，因此不推断其赏金金额。金额使用 `M=百万`、`k=千` 的紧凑记法，精确值见机器快照。重复 Award record 不相加，Project、仓库、Issue、PR、CI 和 checkpoint 仍不是数学 Evidence、Result 或 Solution。
 
 | 排名 | 类别 | 问题 / Problem Key | 赏金（原币种；USD 等值） | 公开单问题仓库 |
 | ---: | --- | --- | ---: | --- |
+| 重点 | 独立密码学重点问题 | `secp256k1`：离散对数经典多项式时间性审计 | Project #2 未登记赏金 | [vibemathing/problem-secp256k1-ecdlog-polytime](https://github.com/vibemathing/problem-secp256k1-ecdlog-polytime) |
 | 1 | Project #2 赏金问题 | `eternity-ii`：Eternity II puzzle | USD 2M | [vibemathing/problem-eternity-ii](https://github.com/vibemathing/problem-eternity-ii) |
 | 2 | Project #2 赏金问题 | `beal-million`：Beal猜想 | USD 1M | [vibemathing/problem-um-nt-078-beal-s-conjecture-c75e225d](https://github.com/vibemathing/problem-um-nt-078-beal-s-conjecture-c75e225d) |
 | 3 | 千禧年问题 | `clay-bsd`：Birch–Swinnerton-Dyer猜想 | USD 1M | [vibemathing/problem-millennium-birch-swinnerton-dyer](https://github.com/vibemathing/problem-millennium-birch-swinnerton-dyer) |
@@ -190,8 +191,6 @@
 | 144 | Project #2 赏金问题 | `erdosproblems:104`：Erdős Problem #104 | USD 100 | [vibemathing/problem-um-ep-104-erd-s-problem-104-15bd3bf4](https://github.com/vibemathing/problem-um-ep-104-erd-s-problem-104-15bd3bf4) |
 | 145 | Project #2 赏金问题 | `erdosproblems:1123`：Erdős Problem #1123 | USD 100 | [vibemathing/problem-erdosproblems-1123](https://github.com/vibemathing/problem-erdosproblems-1123) |
 | 146 | Project #2 赏金问题 | `erdosproblems:119`：Erdős Problem #119 | USD 100 | [vibemathing/problem-erdosproblems-119](https://github.com/vibemathing/problem-erdosproblems-119) |
-| — | 独立密码学问题 | `secp256k1`：离散对数经典多项式时间性审计 | 未列入 Project #2 Top 146 赏金排名 | [vibemathing/problem-secp256k1-ecdlog-polytime](https://github.com/vibemathing/problem-secp256k1-ecdlog-polytime) |
-
 ## 30 秒理解
 
 | 你想知道 | 直接答案 |

--- a/scripts/check_public_readme.py
+++ b/scripts/check_public_readme.py
@@ -596,6 +596,10 @@ def check_bounty_readme_tables(root: Path) -> None:
             raise CheckError(f"{relative} must contain inline Project #2 ranks 1..146")
         if "problem-secp256k1-ecdlog-polytime" not in text:
             raise CheckError(f"{relative} is missing the separate secp256k1 entry")
+        table_lines = text.splitlines()
+        header_index = next((index for index, line in enumerate(table_lines) if header in line), None)
+        if header_index is None or header_index + 2 >= len(table_lines) or "secp256k1" not in table_lines[header_index + 2]:
+            raise CheckError(f"{relative} must place secp256k1 in the first table row")
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

- Move the independent secp256k1 research entry to the first row of the README problem table as a featured focus item.
- Keep it explicitly outside the Project #2 Top-146 bounty ranking and do not infer a bounty amount.
- Keep the ordered Project #2 rows 1..146 unchanged below it.
- Add a validator assertion that secp256k1 remains the first table row.

## Verification

- `make check`
- `python3 scripts/check_public_readme.py --project-root .`
- `python3 scripts/check_ai_citation_assets.py --project-root .`
- `python3 scripts/validate_public_boundary.py --project-root .`
